### PR TITLE
refactor: change import aliases to '@'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,12 +31,7 @@ module.exports = {
     'import/resolver': {
       'eslint-import-resolver-custom-alias': {
         alias: {
-          '@api': './src/api',
-          '@assets': './src/assets',
-          '@components': './src/components',
-          '@config': './src/config',
-          '@pages': './src/pages',
-          '@store': './src/store',
+          '@': './src',
         },
         extensions: ['.js', '.jsx'],
       },

--- a/craco.config.js
+++ b/craco.config.js
@@ -4,12 +4,7 @@ const { ESLINT_MODES } = require('@craco/craco');
 module.exports = {
   webpack: {
     alias: {
-      '@api': path.resolve(__dirname, 'src/api/'),
-      '@assets': path.resolve(__dirname, 'src/assets/'),
-      '@components': path.resolve(__dirname, 'src/components/'),
-      '@config': path.resolve(__dirname, 'src/config/'),
-      '@pages': path.resolve(__dirname, 'src/pages/'),
-      '@store': path.resolve(__dirname, 'src/store/'),
+      '@': path.resolve(__dirname, 'src/'),
     },
   },
   eslint: {

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,12 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@api/*": ["./src/api/*"],
-      "@assets/*": ["./src/assets/*"],
-      "@components/*": ["./src/components/*"],
-      "@config/*": ["./src/config/*"],
-      "@pages/*": ["./src/pages/*"],
-      "@store/*": ["./src/store/*"]
+      "@/*": ["./src/*"]
     }
   },
   "exclude": ["node_modules/"]

--- a/src/api/base.api.js
+++ b/src/api/base.api.js
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import config from '@config';
+import config from '@/config';
 
 const baseApi = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: config.apiUrl }),

--- a/src/components/layout/navbar.component.jsx
+++ b/src/components/layout/navbar.component.jsx
@@ -10,7 +10,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { toggleType } from '@store/modules/theme/theme.slice';
+import { toggleType } from '@/store/modules/theme/theme.slice';
 
 export default function Navbar() {
   const navigate = useNavigate();

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
-import { store, persistor } from '@store';
+import { store, persistor } from '@/store';
 import App from './app';
 
 ReactDOM.render(

--- a/src/pages/auth/sign-in.page.jsx
+++ b/src/pages/auth/sign-in.page.jsx
@@ -8,7 +8,7 @@ import Typography from '@mui/material/Typography';
 import { Link as RouterLink } from 'react-router-dom';
 import { Formik, Form } from 'formik';
 import * as Yup from 'yup';
-import Hero from '@components/layout/hero.component';
+import Hero from '@/components/layout/hero.component';
 
 const validationSchema = Yup.object({
   email: Yup.string().email('Must be a valid email').required('Required'),

--- a/src/pages/auth/sign-up.page.jsx
+++ b/src/pages/auth/sign-up.page.jsx
@@ -12,7 +12,7 @@ import Typography from '@mui/material/Typography';
 import { Link as RouterLink } from 'react-router-dom';
 import { Formik, Form } from 'formik';
 import * as Yup from 'yup';
-import Hero from '@components/layout/hero.component';
+import Hero from '@/components/layout/hero.component';
 
 const validationSchema = Yup.object({
   email: Yup.string().email('Must be a valid email').required('Required'),

--- a/src/pages/errors/not-found.page.jsx
+++ b/src/pages/errors/not-found.page.jsx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import { Link as RouterLink } from 'react-router-dom';
-import Hero from '@components/layout/hero.component';
+import Hero from '@/components/layout/hero.component';
 
 export default function NotFoundPage() {
   return (

--- a/src/pages/static/home.page.jsx
+++ b/src/pages/static/home.page.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Typography from '@mui/material/Typography';
-import Hero from '@components/layout/hero.component';
+import Hero from '@/components/layout/hero.component';
 
 export default function HomePage() {
   return (

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import Footer from '@components/layout/footer.component';
-import HomePage from '@pages/static/home.page';
-import Navbar from '@components/layout/navbar.component';
-import NotFoundPage from '@pages/errors/not-found.page';
-import SignInPage from '@pages/auth/sign-in.page';
-import SignUpPage from '@pages/auth/sign-up.page';
+import Footer from '@/components/layout/footer.component';
+import HomePage from '@/pages/static/home.page';
+import Navbar from '@/components/layout/navbar.component';
+import NotFoundPage from '@/pages/errors/not-found.page';
+import SignInPage from '@/pages/auth/sign-in.page';
+import SignUpPage from '@/pages/auth/sign-up.page';
 
 export default function Router() {
   return (

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,7 +10,7 @@ import {
   PURGE,
   REGISTER,
 } from 'redux-persist';
-import baseApi from '@api/base.api';
+import baseApi from '@/api/base.api';
 import reducer from './modules';
 
 const persistConfig = {

--- a/src/store/modules/index.js
+++ b/src/store/modules/index.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux';
-import baseApi from '@api/base.api';
+import baseApi from '@/api/base.api';
 import theme from './theme/theme.slice';
 
 export default combineReducers({


### PR DESCRIPTION
## Description

This pull request aims to change all import aliases to just `@` (referencing the src directory).

This way you can add all the folders you like and just use a "@/" to access it, instead of having to define it in three different files, just like it was before. 

## Requirements

None.

## Additional changes

None.
